### PR TITLE
docs: improve Rust doc comments and mdBook

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -2,6 +2,8 @@
 
 [Overview](./overview.md)
 
+- [Getting Started](./getting_started.md)
+
 - [Newton-Cotes method](./newton-cotes.md)
 
   - [Rectangle rule](newton_cotes/rectangle_rule.md)
@@ -21,3 +23,5 @@
   - [Adaptive Simpson](adaptive_quadrature/adaptive_simpson.md)
 
 - [Romberg's method](./romberg.md)
+
+- [Python API](./python_api.md)

--- a/book/src/adaptive_quadrature/adaptive_simpson.md
+++ b/book/src/adaptive_quadrature/adaptive_simpson.md
@@ -1,5 +1,9 @@
 # Adaptive Simpson
 
+## Motivation
+
+Fixed-step quadrature methods use the same subinterval size everywhere, which is inefficient when the integrand is smooth in most of the domain but has rapid variation or near-singularities in a small region. Adaptive quadrature automatically concentrates function evaluations where the integrand is hardest to approximate, achieving a target accuracy with fewer total evaluations.
+
 ## Example
 
 ```rust, editable
@@ -37,3 +41,7 @@ Adaptive techniques are attempts to automatically detect and control the length 
 
 The technique for which the link to the listing is given below uses Simpson's rule
 for integrating a function \\(f(x)\\) on a closed and bounded interval \\(\[a,b\]\\).
+
+## Limitations
+
+The adaptive Simpson method requires the integrand to be continuous on \\([a, b]\\). It may fail or produce unreliable results for functions with true singularities or jump discontinuities. The recursion depth is implicitly bounded by `min_h`; choosing `min_h` too large may miss fine structure, while too small a value can cause excessive recursion.

--- a/book/src/gauss_quadrature/gauss_chebyshev.md
+++ b/book/src/gauss_quadrature/gauss_chebyshev.md
@@ -22,7 +22,7 @@ println!("{}",integral);
 With respect to the inner product
 
 \\[
-\langle f,g \rangle = \int\_{-\infty}^{+\infty} f(x) \cdot g(x) \cdot w(x) dx
+\langle f,g \rangle = \int\_{-1}^{1} f(x) \cdot g(x) \cdot w(x) dx
 \\]
 
 the Chebyshev polynomials are defined by
@@ -63,7 +63,7 @@ println!("{}",integral);
 With respect to the inner product
 
 \\[
-\langle f,g \rangle = \int\_{-\infty}^{+\infty} f(x) \cdot g(x) \cdot w(x) dx
+\langle f,g \rangle = \int\_{-1}^{1} f(x) \cdot g(x) \cdot w(x) dx
 \\]
 
 the Chebyshev polynomials are defined by
@@ -86,6 +86,6 @@ where \\(x_i\\), \\(i = 1,\dots,n\\), are the zeros of \\(U_n\\) and
 A_i = \frac{\pi}{n + 1} \cdot \sin^2\left(\frac{i\pi}{n + 1} \right) \quad \text{for} \quad i = 1,\dots,n.
 \\]
 
-```
+## Limitations
 
-```
+Gauss-Chebyshev quadrature is only suitable when the integrand can be expressed in the weighted form \\(f(x)/\sqrt{1-x^2}\\) (first kind) or \\(f(x)\sqrt{1-x^2}\\) (second kind) on \\([-1, 1]\\). It is not appropriate for functions on other intervals or without the corresponding weight factor, as the accuracy guarantees rely on orthogonality with respect to that weight.

--- a/book/src/gauss_quadrature/gauss_hermite.md
+++ b/book/src/gauss_quadrature/gauss_hermite.md
@@ -1,5 +1,9 @@
 # Gauss Hermite
 
+## Motivation
+
+Gauss-Hermite quadrature is designed for integrals of the form \\(\int_{-\infty}^{+\infty} f(x)\\,e^{-x^2}\\,dx\\), which appear naturally in quantum mechanics, probability theory (Gaussian distributions), and signal processing. By exploiting the orthogonality of Hermite polynomials, it provides exponential convergence for smooth integrands with Gaussian-type decay.
+
 ## Example
 
 ```rust,editable
@@ -15,18 +19,18 @@ println!("{}",integral);
 
 ## Understanding Gauss-Hermite rule
 
-Gauss-Hermite quadrature formulas are used to integrate functions \\(f(x) e^{x^2}\\) from \\(-\infty\\) to \\(+\infty\\).
+Gauss-Hermite quadrature formulas are used to integrate functions \\(f(x) e^{-x^2}\\) from \\(-\infty\\) to \\(+\infty\\).
 
 With respect to the inner product
 
 \\[
-\langle f,g \rangle = \int_{-\infty}^{+\infty} f(x) * g(x) * w(x) dx
+\langle f,g \rangle = \int_{-\infty}^{+\infty} f(x) \cdot g(x) \cdot w(x) \, dx
 \\]
 
 the Hermite polynomials
 
 \\[
-H_n(x) = (-1)^n * e^{x^2}* \frac{\partial^{n} e^{-x^2}}{\partial x^n} \quad \text{for} \quad n > 0
+H_n(x) = (-1)^n \cdot e^{x^2} \cdot \frac{\partial^{n} e^{-x^2}}{\partial x^n} \quad \text{for} \quad n > 0
 \\]
 
 and \\(H_0(x) = 1\\) form an orthogonal family of polynomials with weight function \\(w(x) = e^{-x^2}\\) on the entire \\(x\\)-axis.
@@ -34,11 +38,15 @@ and \\(H_0(x) = 1\\) form an orthogonal family of polynomials with weight functi
 The \\(n\\)-point Gauss-Hermite quadrature formula, \\(GH_n ( f(x) )\\), for approximating the integral of \\(f(x) e^{-x^2}\\) over the entire \\(x\\)-axis, is given by
 
 \\[
-GH_n ( f(x) ) = A_1 f(x_1) + ··· + A_n f(x_n)
+GH_n ( f(x) ) = A_1 f(x_1) + \cdots + A_n f(x_n)
 \\]
 
-where \\(x_i\\) , for \\(i = 1,...,n\\), are the zeros of \\(H_n\\) and
+where \\(x_i\\), for \\(i = 1,\ldots,n\\), are the zeros of \\(H_n\\) and
 
 \\[
-A_i = \frac{2^{n+1} * n! * \sqrt{\pi}}{H_{n-1} (x_i)^2} \quad \text{for} \quad i = 1,...,n
+A_i = \frac{2^{n+1} \cdot n! \cdot \sqrt{\pi}}{H_{n-1} (x_i)^2} \quad \text{for} \quad i = 1,\ldots,n
 \\]
+
+## Limitations
+
+Gauss-Hermite quadrature is only appropriate for integrals of the form \\(\int_{-\infty}^{+\infty} f(x)\\,e^{-x^2}\\,dx\\). If the integrand does not have Gaussian decay, the method will produce inaccurate results. It is not suitable for integrands on finite intervals or those with non-Gaussian tail behavior.

--- a/book/src/gauss_quadrature/gauss_laguerre.md
+++ b/book/src/gauss_quadrature/gauss_laguerre.md
@@ -1,5 +1,9 @@
 # Gauss-Laguerre
 
+## Motivation
+
+Gauss-Laguerre quadrature is designed for integrals of the form \\(\int_0^{+\infty} f(x)\\,e^{-x}\\,dx\\), where the exponential decay naturally arises in probability distributions, physics, and engineering problems. By using the zeros and weights of Laguerre polynomials, the method achieves high accuracy with far fewer function evaluations than general-purpose rules on a truncated domain.
+
 ## Example
 
 ```rust,editable
@@ -42,3 +46,7 @@ where \\(x_i\\), \\(i = 1,\dots,n\\), are the zeros of \\(L_n\\) and
 \\[
 A_i = \dfrac{n!^2}{ x_i L\_{n-1} (x_i)^2} \quad \text{for} \quad i = 1,\dots,n
 \\]
+
+## Limitations
+
+Gauss-Laguerre quadrature is only appropriate for integrals of the form \\(\int_0^{+\infty} f(x)\\,e^{-x}\\,dx\\). If the integrand does not have exponential decay, the method will produce inaccurate results. It is also not suitable for integrands defined on finite intervals or on the full real line.

--- a/book/src/gauss_quadrature/gauss_legendre.md
+++ b/book/src/gauss_quadrature/gauss_legendre.md
@@ -84,6 +84,10 @@ The truncation error is
 
 where \\(K\\) is a constant, and \\(c\\) is some unknown number that verifies \\(a < c < b\\).
 
+## Limitations
+
+Gauss-Legendre quadrature is best suited for smooth functions on finite intervals. It is not appropriate for functions with singularities, discontinuities, or functions defined on unbounded domains. Rapidly oscillating functions may also require specialized treatment or a very large number of nodes \\(n\\).
+
 ## References:
 
 Original C++ code implemented by **Ignace Bogaert**.
@@ -92,7 +96,6 @@ The main features of this software are:
 
 - **Speed**: due to the simple formulas and the \\(O(1)\\) complexity computation of
   individual Gauss-Legendre quadrature nodes and weights.
-  This makes it compatible with parallel computing paradigms.
 - **Accuracy**: the error on the nodes and weights is within a few ulps.
 
 ### Ignace Bogaert's Paper:

--- a/book/src/getting_started.md
+++ b/book/src/getting_started.md
@@ -1,0 +1,55 @@
+# Getting Started
+
+## Installation
+
+Add `integrate` to your `Cargo.toml`:
+
+```toml
+[dependencies]
+integrate = "0.1"
+```
+
+## Your First Integral
+
+Let's compute \\(\int_0^1 e^x \\, dx = e - 1 \approx 1.71828\\) using the trapezoidal rule:
+
+```rust,editable
+use integrate::newton_cotes::trapezoidal_rule;
+
+let result = trapezoidal_rule(|x: f64| x.exp(), 0.0_f64, 1.0_f64, 1_000_usize);
+println!("Result:   {:.6}", result);
+println!("Exact:    {:.6}", std::f64::consts::E - 1.0);
+```
+
+## Using the Prelude
+
+For convenience, you can import all methods at once with:
+
+```rust
+use integrate::prelude::*;
+```
+
+This exposes all 11 integration functions directly.
+
+## Choosing a Method
+
+| You want to integrate… | Recommended method |
+|---|---|
+| A smooth function on \\([a, b]\\) | [`legendre_rule`] or [`trapezoidal_rule`] |
+| A function with variable smoothness | [`adaptive_simpson_method`] |
+| A smooth function to high precision | [`romberg_method`] |
+| \\(f(x)\\,e^{-x}\\) over \\([0, \infty)\\) | [`gauss_laguerre_rule`] |
+| \\(f(x)\\,e^{-x^2}\\) over \\((-\infty, \infty)\\) | [`gauss_hermite_rule`] |
+| \\(f(x)/\sqrt{1-x^2}\\) over \\([-1,1]\\) | [`gauss_chebyshev1_rule`] |
+| \\(f(x)\sqrt{1-x^2}\\) over \\([-1,1]\\) | [`gauss_chebyshev2_rule`] |
+
+## Generics: f32 and f64
+
+All Newton-Cotes and Romberg methods are generic over float types. You can pass `f32` functions:
+
+```rust,editable
+use integrate::newton_cotes::simpson_rule;
+
+let result = simpson_rule(|x: f32| x * x, 0.0_f32, 1.0_f32, 1_000_usize);
+println!("{:.6}", result); // ≈ 0.333333
+```

--- a/book/src/newton_cotes/newton_rule.md
+++ b/book/src/newton_cotes/newton_rule.md
@@ -1,5 +1,9 @@
 # Newton's 3/8 rule
 
+## Motivation
+
+Newton's 3/8 rule fits a cubic polynomial through four equally-spaced points per subinterval and integrates it exactly. It achieves the same order of accuracy as Simpson's rule (\\(O(h^4)\\)) but uses three subintervals at a time, making it useful when the number of subintervals is a multiple of three.
+
 ## Example
 
 ```rust, editable
@@ -16,7 +20,7 @@ let num_steps: usize = 1_000_000;
 let integral = newton_rule(square, a, b, num_steps);
 ```
 
-## Understanding Newton'3/8 rule
+## Understanding Newton's 3/8 rule
 
 Newton's \\(3/8\\) rule approximates the integral of a function \\(f(x)\\) on the closed and bounded
 interval \\(\[a, a+h\]\\) of length \\(h > 0\\) by the integral on \\(\[a, a+h\]\\) of the cubic passing
@@ -35,7 +39,7 @@ be the result of applying the Newton's 3/8 rule with \\(n\\) subintervals of len
 \\[
 \begin{align}
 N_h(f) &= \frac{h}{8} \left[ f(a) + 3 f\left(a+ \frac{h}{3} \right) + 3f\left(a+ \frac{2h}{3} \right) + 2 f(a + h) \right.\\\\
-& \left. + ··· + 2f(b-h) + 3f \left( b-\frac{2h}{3} \right) + 3f \left( b - \frac{h}{3} \right) + f(b) \right]
+& \left. + \cdots + 2f(b-h) + 3f \left( b-\frac{2h}{3} \right) + 3f \left( b - \frac{h}{3} \right) + f(b) \right]
 \end{align}
 \\]
 
@@ -43,8 +47,8 @@ An immediate consequence of the Euler-Maclaurin summation formula relates \\(\in
 
 \\[
 \begin{align}
-N_h(f) &= \int\_{a}^{b} f(x)dx + \frac{h^4}{6480} \left[ f^{3}(b) - f^{3}(a) \right] - \frac{h^6}{244944} \left[ f^{(5)}(b) - f^{(5)}(a) \right] \\\\
-& + ··· + K h^{2p-2} \left[ f^{(2p - 3)}(b) - f^{(2p - 3)}(a) \right] + O(h^{2p})
+N_h(f) &= \int\_{a}^{b} f(x)dx + \frac{h^4}{6480} \left[ f^{(3)}(b) - f^{(3)}(a) \right] - \frac{h^6}{244944} \left[ f^{(5)}(b) - f^{(5)}(a) \right] \\\\
+& + \cdots + K h^{2p-2} \left[ f^{(2p - 3)}(b) - f^{(2p - 3)}(a) \right] + O(h^{2p})
 \end{align}
 \\]
 
@@ -54,16 +58,14 @@ of \\(f\\) and \\(K\\) is a constant.
 The last term, \\(O(h^{2p})\\) is important. Given an infinitely differentiable function in which the
 first \\(2p-3\\) derivatives vanish at both endpoints of the interval of integration, it is not true that
 
-\begin{align}
+\\[
 N_h(f) = \int\_{a}^{b} f(x) dx
-\end{align}
+\\]
 
 but rather what the theorem says is that
 
 \\[
-\begin{align}
-\lim_{h \to 0} \mid \frac{N_h(f) - \int_{a}^{b} f(x)dx}{h^{2p}} \mid < M
-\end{align}
+\lim_{h \to 0} \left| \frac{N_h(f) - \int_{a}^{b} f(x)dx}{h^{2p}} \right| < M
 \\]
 
 where \\(M > 0\\).
@@ -74,7 +76,7 @@ mean-value theorem to
 \\[
 \begin{align}
 N_h(f) - \int\_{a}^{b} f(x)dx &= \frac{h^4}{6480} \left[ f^{(3)}(b) - f^{(3)}(a) \right] - \frac{h^6}{244944} \left[ f^{(5)}(b) - f^{(5)}(a) \right] \\\\
-& + ··· + K h^{2p - 2} \left[ f^{(2p - 3)}(b) - f^{(2p - 3)}(a) \right] + O(h^{2p})
+& + \cdots + K h^{2p - 2} \left[ f^{(2p - 3)}(b) - f^{(2p - 3)}(a) \right] + O(h^{2p})
 \end{align}
 \\]
 
@@ -84,7 +86,7 @@ yields the standard truncation error expression
 N_h(f) - \int_{a}^{b} f(x)dx = \frac{h^4}{6480} (b-a) f^{(4)}(c)
 \\]
 
-for some point $c$ where \\(a ≤ c ≤ b\\).
+for some point \\(c\\) where \\(a \leq c \leq b\\).
 
 A corollary of which is that if \\(f^{(4)}(x) = 0\\) for all \\(x\\) in \\(\[a,b\]\\), i.e. if \\(f(x)\\) is a cubic,
 then Newton's 3/8 rule is exact.
@@ -96,7 +98,7 @@ For example, if \\(h = 0.1\\) then
 \\[
 \begin{align}
 N\_{0.1}(f) &= \int\_{a}^{b} f(x)dx + 1.5·10^{-8} \left[ f^{(3)}(b) - f^{(3)}(a) \right] \\\\
-&- 4.1 · 10^{-12} \left[ f^{(5)}(b) - f^{(5)}(a) \right] + ···
+&- 4.1 \cdot 10^{-12} \left[ f^{(5)}(b) - f^{(5)}(a) \right] + \cdots
 \end{align}
 \\]
 
@@ -104,16 +106,22 @@ and if \\(h = 0.01\\) then
 
 \\[
 \begin{align}
-N\_{0.01}(f) &= \int\_{a}^{b} f(x)dx + 1.5·10^{-12} [ f^{3}(b) - f^{3}(a) ] \\\\
-&- 4.1·10^{-18} [ f^{(5)}(b) - f^{(5)}(a) ] + ···
+N\_{0.01}(f) &= \int\_{a}^{b} f(x)dx + 1.5 \cdot 10^{-12} \left[ f^{(3)}(b) - f^{(3)}(a) \right] \\\\
+&- 4.1 \cdot 10^{-18} \left[ f^{(5)}(b) - f^{(5)}(a) \right] + \cdots
 \end{align}
 \\]
 
 while if \\(h = 10\\) then
 
+\\[
 \begin{align}
 N\_{10}(f) &= \int\_{a}^{b} f(x)dx + 1.54 \left[ f^{(3)}(b) - f^{(3)}(a) \right] \\\\
-&- 4.08 \left[ f^{(5)}(b) - f^{(5)}(a) \right] + ···
+&- 4.08 \left[ f^{(5)}(b) - f^{(5)}(a) \right] + \cdots
 \end{align}
+\\]
 
 However, if the function \\(f(x)\\) is a cubic, then \\(n\\) may be chosen to be \\(1\\).
+
+## Limitations
+
+Newton's 3/8 rule converges as \\(O(h^4)\\), the same order as Simpson's rule, but requires the number of subintervals to be a multiple of three. For general use, Simpson's rule is more flexible. Like all fixed-step Newton-Cotes formulas, it is not suitable for integrands with discontinuities or singularities.

--- a/book/src/newton_cotes/rectangle_rule.md
+++ b/book/src/newton_cotes/rectangle_rule.md
@@ -1,5 +1,9 @@
 # Rectangle rule
 
+## Motivation
+
+The rectangle rule (also called the midpoint rule) is the simplest Newton-Cotes formula for numerical integration. It is useful as a baseline method and is exact for constant functions. The composite form approximates a definite integral by summing rectangle areas, making it easy to implement.
+
 ## Example
 
 ```rust,editable
@@ -37,16 +41,18 @@ Let \\(\int\_{a}^{b} f(x) dx\\) be the integral of \\(f(x)\\) over the closed an
 and let \\(R_h(f)\\) be the result of applying the rectangle rule with \\(n\\) subintervals of length \\(h\\), i.e.
 
 \\[
-R_h(f)=h \left[ f\left( a+\frac{h}{2} \right) + f\left(a+\frac{3h}{2}\right) + ··· + f\left(b-\frac{h}{2}\right) \right]
+R_h(f)=h \left[ f\left( a+\frac{h}{2} \right) + f\left(a+\frac{3h}{2}\right) + \cdots + f\left(b-\frac{h}{2}\right) \right]
 \\]
 
 An immediate consequence of the Euler-Maclaurin summation formula yields the following equation
 relating \\(\int\_{a}^{b} f(x) dx\\) and \\(R_h(f)\\):
 
+\\[
 \begin{align}
 R_h(f) & = \int\_{a}^{b} f(x) dx - \frac{h^2}{24} \left[ f^\prime (b) - f^\prime (a) \right] + \frac{7h^4}{5760} \left[ f^{(3)}(b) - f^{(3)}(a) \right] + \\\\
-& ··· + K h^{2p-2} \left[ f^{(2p-3)}(b) - f^{(2p-3)}(a) \right] + O(h^{2p})
+& \cdots + K h^{2p-2} \left[ f^{(2p-3)}(b) - f^{(2p-3)}(a) \right] + O(h^{2p})
 \end{align}
+\\]
 
 where \\(f'\\), \\(f^{(3)}\\), and \\(f^{(2p-3)}\\) are the first, third and \\((2p-3)^{rd}\\) derivatives of \\(f\\) and \\(K\\) is a constant.
 
@@ -63,7 +69,11 @@ where \\(M>0\\).
 If \\(f\\) is at least twice differentiable on the interval \\(\[a,b\]\\), then applying the mean-value
 theorem to
 
-\begin{align} R_h(f) - \int\_{a}^{b} f(x) dx & = -\frac{h^2}{24} \left[ f^\prime (b) - f^\prime (a) \right] + \frac{7h^4}{5760} \left[ f^{(3)}(b) - f^{(3)}(a) \right] \\\\ & + ··· + K h^{2p-2} \left[ f^{(2p-3)}(b) - f^{(2p-3)}(a) \right] + O(h^{2p})\end{align}
+\\[
+\begin{align}
+R_h(f) - \int\_{a}^{b} f(x) dx & = -\frac{h^2}{24} \left[ f^\prime (b) - f^\prime (a) \right] + \frac{7h^4}{5760} \left[ f^{(3)}(b) - f^{(3)}(a) \right] \\\\ & + \cdots + K h^{2p-2} \left[ f^{(2p-3)}(b) - f^{(2p-3)}(a) \right] + O(h^{2p})
+\end{align}
+\\]
 
 yields the standard truncation error expression
 
@@ -73,20 +83,30 @@ R_h(f) - \int_{a}^{b} f(x) dx = -\frac{h^2}{24} (b - a) f^{\prime\prime}(c)
 
 for some point \\(c\\) where \\(a ≤ c ≤ b\\).
 
-A corollary of which is that if \\(f''(x) = 0\\) for all \\(x\\) in \\(\[a,b\]\\),
+A corollary of which is that if \\(f^{\prime\prime}(x) = 0\\) for all \\(x\\) in \\(\[a,b\]\\),
 i.e. if \\(f(x)\\) is linear, then the rectangle rule is exact.
 
 The Euler-Maclaurin summation formula also shows that usually \\(n\\) should be chosen large enough
 so that \\(h = \frac{b-a}{n} < 1\\). For example, if \\(h = 0.1\\) then
 
-\begin{split} R\_{0.1}(f) &= \int\_{a}^{b} f(x) dx - 0.00042 \left[ f'(b) - f'(a) \right] \\\\ & + 0.00000012 \left[f^{(3)}(b) - f^{(3)}(a) \right] + ... \end{split}
+\\[
+\begin{split} R\_{0.1}(f) &= \int\_{a}^{b} f(x) dx - 0.00042 \left[ f^\prime(b) - f^\prime(a) \right] \\\\ & + 0.00000012 \left[f^{(3)}(b) - f^{(3)}(a) \right] + \cdots \end{split}
+\\]
 
 and if \\(h = 0.01\\) then
 
-\begin{split} R\_{0.01}(f) &= \int\_{a}^{b} f(x) dx - 0.0000042 \left[ f^\prime(b) - f^\prime(a) \right] \\\\ &+ 0.000000000012 \left[ f^{(3)}(b) - f^{(3)}(a) \right] + ... \end{split}
+\\[
+\begin{split} R\_{0.01}(f) &= \int\_{a}^{b} f(x) dx - 0.0000042 \left[ f^\prime(b) - f^\prime(a) \right] \\\\ &+ 0.000000000012 \left[ f^{(3)}(b) - f^{(3)}(a) \right] + \cdots \end{split}
+\\]
 
 while if \\(h=10\\) then
 
-\begin{split} R\_{10}(f) &= \int\_{a}^{b} f(x) dx - 4.1667 \left[ f^\prime(b) - f^\prime(a)\right] \\\\ &+ 12.15 \left[ f^{(3)}(b) - f^{(3)}(a) \right] + ... \end{split}
+\\[
+\begin{split} R\_{10}(f) &= \int\_{a}^{b} f(x) dx - 4.1667 \left[ f^\prime(b) - f^\prime(a)\right] \\\\ &+ 12.15 \left[ f^{(3)}(b) - f^{(3)}(a) \right] + \cdots \end{split}
+\\]
 
 However, if the function \\(f(x)\\) is linear, then \\(n\\) may be chosen to be \\(1\\).
+
+## Limitations
+
+The rectangle rule converges as \\(O(h^2)\\), making it the least accurate of the Newton-Cotes rules. Prefer Simpson's rule for smooth integrands.

--- a/book/src/newton_cotes/simpson_rule.md
+++ b/book/src/newton_cotes/simpson_rule.md
@@ -1,5 +1,9 @@
 # Simpson's rule
 
+## Motivation
+
+Simpson's rule fits a quadratic polynomial through each pair of subintervals and integrates it exactly, yielding fourth-order convergence for smooth functions. It is one of the most widely used Newton-Cotes formulas and is exact for polynomials of degree three or less.
+
 ## Example
 
 ```rust, editable
@@ -34,7 +38,7 @@ Simpson's rule. Let \\(\int\_{a}^{b} f(x) dx\\) be the integral of \\(f(x)\\) ov
 \\[
 \begin{align}
 S_h(f) &= \frac{h}{6} \left[ f(a) + 4f(a+\frac{h}{2}) + 2f(a+h) \right. \\\\
-& + \left. ··· + 2f(b-h) + 4f(b-\frac{h}{2}) + f(b) \right]
+& + \left. \cdots + 2f(b-h) + 4f(b-\frac{h}{2}) + f(b) \right]
 \end{align}
 \\]
 
@@ -43,7 +47,7 @@ An immediate consequence of the Euler-Maclaurin summation formula relates \\(\in
 \\[
 \begin{align}
 S_h(f) & = \int\_{a}^{b} f(x) dx + \frac{h^4}{2880} \left[ f^{(3)}(b) - f^{(3)}(a) \right] - \frac{h^6}{96768} \left[ f^{(5)}(b) - f^{(5)}(a) \right] \\\\
-& + ··· + K h^{2p-2} \left[ f^{(2p-3)}(b) - f^{(2p-3)}(a) \right] + O(h^{2p})
+& + \cdots + K h^{2p-2} \left[ f^{(2p-3)}(b) - f^{(2p-3)}(a) \right] + O(h^{2p})
 \end{align}
 \\]
 
@@ -69,7 +73,7 @@ If \\(f\\) is at least four times differentiable on the interval \\(\[a,b\]\\), 
 \\[
 \begin{align}
 S_h(f) - \int\_{a}^{b}f( x ) dx &= \frac{h^4}{2880} \left[ f^{(3)}(b) - f^{(3)}(a) \right] - \frac{h^6}{96768} \left[ f^{(5)}(b) - f^{(5)}(a) \right] \\\\
-&+ ··· + K h^{(2p - 2)} \left[f^{(2p-3)}(b) - f^{(2p-3)}(a) \right] + O(h^{2p})
+&+ \cdots + K h^{(2p - 2)} \left[f^{(2p-3)}(b) - f^{(2p-3)}(a) \right] + O(h^{2p})
 \end{align}
 \\]
 
@@ -89,8 +93,8 @@ The Euler-Maclaurin summation formula also shows that usually $n$ should be chos
 For example, if \\(h = 0.1\\) then
 \\[
 \begin{align}
-S\_{0.1}(f) & = \int\_{a}^{b} f(x) dx + 3.5 · 10^{-8} \left[ f^{3}(b) - f^{3}(a) \right] \\\\
-& - 1.033 · 10^{-11} \left[ f^{(5)}(b) - f^{(5)}(a) \right] + ···
+S\_{0.1}(f) & = \int\_{a}^{b} f(x) dx + 3.5 \cdot 10^{-8} \left[ f^{(3)}(b) - f^{(3)}(a) \right] \\\\
+& - 1.033 \cdot 10^{-11} \left[ f^{(5)}(b) - f^{(5)}(a) \right] + \cdots
 \end{align}
 \\]
 
@@ -98,17 +102,21 @@ and if \\(h = 0.01\\) then
 
 \\[
 \begin{split}
-S\_{0.01}(f) & = \int\_{a}^{b} f(x) dx + 3.5 · 10^{-12} \left[ f^{3}(b) - f^{3}(a) \right] \\\\
-& - 1.033 · 10^{-17} \left[ f^{(5)}(b) - f^{(5)}(a) \right] + ···
+S\_{0.01}(f) & = \int\_{a}^{b} f(x) dx + 3.5 \cdot 10^{-12} \left[ f^{(3)}(b) - f^{(3)}(a) \right] \\\\
+& - 1.033 \cdot 10^{-17} \left[ f^{(5)}(b) - f^{(5)}(a) \right] + \cdots
 \end{split}
 \\]
 
 while if \\(h = 10\\) then
 \\[
 \begin{align}
-S\_{0.01}(f) & = \int\_{a}^{b} f(x) dx + 3.47 \left[ f^{3}(b) - f^{3}(a) \right] \\\\
-& - 10.33 \left[ f^{(5)}(b) - f^{(5)}(a) \right] + ···
+S\_{0.01}(f) & = \int\_{a}^{b} f(x) dx + 3.47 \left[ f^{(3)}(b) - f^{(3)}(a) \right] \\\\
+& - 10.33 \left[ f^{(5)}(b) - f^{(5)}(a) \right] + \cdots
 \end{align}
 \\]
 
-However, if the function \\[f(x)\\] is a cubic, then \\[n\\] may be chosen to be \\[1\\].
+However, if the function \\(f(x)\\) is a cubic, then \\(n\\) may be chosen to be \\(1\\).
+
+## Limitations
+
+Simpson's rule converges as \\(O(h^4)\\) and requires at least twice-differentiable integrands for its error estimate to apply. It is not suitable for functions with discontinuities or singularities without splitting the interval. For functions with highly variable smoothness, prefer the adaptive Simpson method.

--- a/book/src/newton_cotes/trapezoidal_rule.md
+++ b/book/src/newton_cotes/trapezoidal_rule.md
@@ -1,5 +1,9 @@
 # Trapezoidal rule
 
+## Motivation
+
+The trapezoidal rule approximates a definite integral by replacing the integrand with straight-line segments between adjacent sample points. It is a practical first choice for smooth functions and is the building block for Richardson extrapolation methods such as Romberg's method.
+
 ## Example
 
 ```rust,editable
@@ -33,7 +37,7 @@ Let \\(\int\_{a}^{b} f(x) dx\\) be the integral of \\(f(x)\\) over the closed an
 let \\(T_h(f)\\) be the result of applying the trapezoidal rule with \\(n\\) subintervals of length \\(h\\), i.e.
 
 \\[
-T_h(f) = h \left[ \frac{f(a)}{2} + f(a+h) + ··· + f(b-h) + \frac{f(b)}{2} \right]
+T_h(f) = h \left[ \frac{f(a)}{2} + f(a+h) + \cdots + f(b-h) + \frac{f(b)}{2} \right]
 \\]
 
 The Euler-Maclaurin summation formula relates \\(\int\_{a}^{b} f(x) dx\\) and \\(T_h (f)\\)
@@ -41,7 +45,7 @@ The Euler-Maclaurin summation formula relates \\(\int\_{a}^{b} f(x) dx\\) and \\
 \\[
 \begin{align}
 T_h(f) &= \int\_{a}^{b} f(x) dx + \frac{h^2}{12} \left[f'(b) - f'(a)\right] - \frac{h^4}{720} \left[f^{(3)}(b) - f^{(3)}(a) \right] \\\\
-&+ ... + K h^{2p-2} \left[f^{(2p-3)}(b) - f^{(2p-3)(a)}\right] + O(h^{2p})
+&+ \cdots + K h^{2p-2} \left[f^{(2p-3)}(b) - f^{(2p-3)}(a)\right] + O(h^{2p})
 \end{align}
 \\]
 
@@ -63,13 +67,13 @@ If \\(f\\) is at least twice differentiable on the interval \\(\[a,b\]\\), then 
 \\[
 \begin{align}
 T_h(f) - \int\_{a}^{b} f(x) dx &= \frac{h^2}{12} \left[f^\prime(b) - f^\prime(a) \right] - \frac{h^4}{720} \left[ f^{(3)}(b) - f^{(3)}(a) \right] \\\\
-&+ ... + K h^{2p-2} \left[f^{(2p-3)}(b) - f^{(2p-3)(a)} \right] + O(h^{2p})
+&+ \cdots + K h^{2p-2} \left[f^{(2p-3)}(b) - f^{(2p-3)}(a) \right] + O(h^{2p})
 \end{align}
 \\]
 
 yields the standard truncation error expression
 \\[
-R\_h(f) - \int\_{a}^{b} f(x) dx = -\frac{h^2}{12} (b - a) f^{\prime\prime}(c)
+T\_h(f) - \int\_{a}^{b} f(x) dx = -\frac{h^2}{12} (b - a) f^{\prime\prime}(c)
 \\]
 
 for some point \\(c\\) where \\(a ≤ c ≤ b\\).
@@ -85,16 +89,20 @@ h = \frac{b-a}{n} < 1
 
 For example, if \\(h = 0.1\\) then
 \\[
-T\_{0.1}(f) = \int\_{a}^{b} f(x) dx - 0.00083 \left[f^\prime(b) - f^\prime(a) \right] + 0.00000014 \left[f^{(3)}(b) - f^{(3)}(a) \right] + ...
+T\_{0.1}(f) = \int\_{a}^{b} f(x) dx - 0.00083 \left[f^\prime(b) - f^\prime(a) \right] + 0.00000014 \left[f^{(3)}(b) - f^{(3)}(a) \right] + \cdots
 \\]
 and if \\(h = 0.01\\) then
 \\[
-T\_{0.01}(f) = \int\_{a}^{b} f(x) dx - 0.0000083 \left[ f^\prime(b) - f^\prime(a) \right] + 0.000000000014 \left[f^{(3)}(b) - f^{(3)}(a)\right] + ...
+T\_{0.01}(f) = \int\_{a}^{b} f(x) dx - 0.0000083 \left[ f^\prime(b) - f^\prime(a) \right] + 0.000000000014 \left[f^{(3)}(b) - f^{(3)}(a)\right] + \cdots
 \\]
 
 while if \\(h=10\\) then
 \\[
-T\_{10}(f) = \int\_{a}^{b} f(x) dx - 8.3333 \left[ f^\prime(b) - f^\prime(a) \right] + 13.89 \left[ f^{(3)}(b) - f^{(3)}(a) \right] + ...
+T\_{10}(f) = \int\_{a}^{b} f(x) dx - 8.3333 \left[ f^\prime(b) - f^\prime(a) \right] + 13.89 \left[ f^{(3)}(b) - f^{(3)}(a) \right] + \cdots
 \\]
 
 However, if the function \\(f(x)\\) is linear, then \\(n\\) may be chosen to be \\(1\\).
+
+## Limitations
+
+The trapezoidal rule converges as \\(O(h^2)\\) for general smooth functions. While more accurate than the rectangle rule, it is outperformed by Simpson's rule for smooth integrands. It should not be used for functions with discontinuities or singularities in \\([a, b]\\) without splitting the interval first.

--- a/book/src/overview.md
+++ b/book/src/overview.md
@@ -20,18 +20,16 @@ any of the numerical algorithms.
 ### Integrand check list
 
 - Are there any singularities of the integrand in the interval of integration?
-- If there are, then can they be removed?
-- A function which has jump discontinuities can be integrated by splitting
-  the interval of integration into subintervals on which the function is continuous,
-  and then numerically integrate over each subinterval and add the results.
-
-- Using integration by parts certain types of singular integrals can be
-  expressed as the sum of a function and a non-singular integral.
-
-- In other cases, an approximation of the integral in a small neighborhood of
-  the singularity can be obtained by hand and the interval of integration can be
-  split into three intervals in which numerical integration can be used on
-  two of them.
+    - If there are, then can they be removed?
+    - A function which has jump discontinuities can be integrated by splitting
+      the interval of integration into subintervals on which the function is continuous,
+      and then numerically integrate over each subinterval and add the results.
+    - Using integration by parts certain types of singular integrals can be
+      expressed as the sum of a function and a non-singular integral.
+    - In other cases, an approximation of the integral in a small neighborhood of
+      the singularity can be obtained by hand and the interval of integration can be
+      split into three intervals in which numerical integration can be used on
+      two of them.
 - Does the function oscillate over the region of integration? If it does,
   then make sure that the step size is chosen to be smaller than the wave length
   of the function. The interval of integration can also be split into subintervals

--- a/book/src/python_api.md
+++ b/book/src/python_api.md
@@ -1,0 +1,94 @@
+# Python API
+
+`integrate-py` exposes all 11 integration methods as a Python package, built with
+[PyO3](https://pyo3.rs) and [Maturin](https://www.maturin.rs). The Rust core is called
+directly from Python, with the GIL released during integration so other Python threads
+can run concurrently.
+
+## Installation
+
+```bash
+pip install integrate-py
+```
+
+Or build from source (requires Rust ≥ 1.63):
+
+```bash
+git clone https://github.com/mtantaoui/Integrate
+cd Integrate/python
+pip install maturin
+maturin develop --release
+```
+
+## Quick start
+
+```python
+import math
+import integrate_py as ig
+
+# ∫₀¹ x² dx = 1/3
+result = ig.legendre_rule(lambda x: x**2, 0.0, 1.0, 100)
+print(f"{result:.10f}")   # 0.3333333333
+
+# ∫₀¹ eˣ dx = e − 1
+result = ig.adaptive_simpson(math.exp, 0.0, 1.0, min_h=1e-3, tol=1e-6)
+print(f"{result:.10f}")   # 1.7182818284
+
+# ∫₀^π sin(x) dx = 2
+result = ig.romberg(math.sin, 0.0, math.pi, n_cols=10)
+print(f"{result:.10f}")   # 2.0000000000
+```
+
+## Available methods
+
+- [Newton-Cotes](python_api/newton_cotes.md)
+- [Gaussian Quadrature](python_api/gaussian.md)
+- [Adaptive Simpson](python_api/adaptive.md)
+- [Romberg](python_api/romberg.md)
+
+## Choosing a method
+
+| You want to integrate… | Recommended |
+|---|---|
+| Smooth \\(f\\) on \\([a, b]\\) | `legendre_rule` or `romberg` |
+| Highly smooth \\(f\\), maximum precision | `romberg` |
+| \\(f\\) with variable smoothness | `adaptive_simpson` |
+| Simple estimate, any \\(f\\) | `trapezoidal_rule` |
+| \\(\int_0^\infty f(x)\\,e^{-x}\\,dx\\) | `gauss_laguerre_rule` |
+| \\(\int_{-\infty}^{\infty} f(x)\\,e^{-x^2}\\,dx\\) | `gauss_hermite_rule` |
+| \\(\int_{-1}^{1} f(x)/\sqrt{1-x^2}\\,dx\\) | `gauss_chebyshev1_rule` |
+| \\(\int_{-1}^{1} f(x)\sqrt{1-x^2}\\,dx\\) | `gauss_chebyshev2_rule` |
+
+## A note on performance
+
+The Rust core runs without Python overhead between function evaluations. For best performance:
+
+- **Prefer methods with small \\(n\\)** (`legendre_rule`, `romberg`, `adaptive_simpson`) — they
+  need far fewer function evaluations than Newton-Cotes for the same accuracy.
+- **Use NumPy-vectorized integrands** when very large \\(n\\) is needed; pre-evaluate into an
+  array and integrate with `numpy.trapezoid` / `scipy.integrate.simpson`.
+- **The GIL is released** during integration, so other Python threads are not blocked
+  while the Rust core computes.
+
+## Benchmarks vs scipy
+
+The table below compares `integrate-py` against the equivalent
+[`scipy.integrate`](https://docs.scipy.org/doc/scipy/reference/integrate.html) methods on
+\\(\int_0^1 e^x\\,dx = e - 1\\), using `pytest-benchmark`. Results will vary by machine.
+
+Run the benchmarks yourself:
+
+```bash
+cd Integrate
+pip install pytest pytest-benchmark scipy numpy maturin
+maturin develop --release --manifest-path python/Cargo.toml
+pytest python/tests/test_integrate.py --benchmark-only -v
+```
+
+| Method | integrate-py | scipy equivalent |
+|---|---|---|
+| `trapezoidal_rule(n=500)` | `pytest-benchmark` | `numpy.trapezoid` |
+| `simpson_rule(n=500)` | `pytest-benchmark` | `scipy.integrate.simpson` |
+| `legendre_rule(n=200)` | `pytest-benchmark` | `scipy.integrate.fixed_quad` |
+| `adaptive_simpson` | `pytest-benchmark` | `scipy.integrate.quad` |
+| `romberg(n_cols=15)` | `pytest-benchmark` | `scipy.integrate.romberg` |

--- a/book/src/romberg.md
+++ b/book/src/romberg.md
@@ -1,5 +1,9 @@
 # Romberg's method
 
+## Motivation
+
+Romberg's method combines Richardson extrapolation with the composite trapezoidal rule to eliminate successive error terms from the Euler-Maclaurin expansion, achieving high-order accuracy without evaluating higher derivatives. It is an excellent choice when high precision is required for smooth integrands on finite intervals.
+
 ## Example
 
 ```rust,editable
@@ -35,7 +39,7 @@ The Euler-Maclaurin summation formula relates the integral of a function \\(f(x)
 a closed and bounded interval \\(\[a,b\]\\) , \\(\int\_{a}^{b} f(x) dx\\), and the composite trapezoidal rule,
 
 \\[
-T_h (f) = h \left[ \frac{f(a)}{2} + f(a+h) + ··· + f(b-h) + \frac{f(b)}{2} \right]
+T_h (f) = h \left[ \frac{f(a)}{2} + f(a+h) + \cdots + f(b-h) + \frac{f(b)}{2} \right]
 \\]
 
 by
@@ -43,7 +47,7 @@ by
 \\[
 \begin{split}
 T_h(f) &= \int\_{a}^{b} f(x) dx + \left(\frac{h^2}{12}\right) \left[f^\prime(b) - f^\prime(a)\right] - \left(\frac{h^4}{720}\right) \left[f^{(3)}(b) - f^{(3)}(a) \right] \\\\
-&+ ... + K h^{2p-2} \left[ f^{(2p-3)}(b) - f^{(2p-3)(a)} \right] + O(h^{2p})
+&+ \cdots + K h^{2p-2} \left[ f^{(2p-3)}(b) - f^{(2p-3)}(a) \right] + O(h^{2p})
 \end{split}
 \\]
 
@@ -55,7 +59,7 @@ If the subinterval length is halved, then
 \\[
 \begin{split}
 T\_{\frac{h}{2}}(f) &= \int\_{a}^{b} f(x) dx + \frac{h^2}{4·12} \left[ f^\prime(b) - f^\prime(a) \right] - \left( \frac{h^4}{16·720} \right) \left[ f^{(3)}(b) - f^{(3)}(a) \right] \\\\
-&+ ... + K \left( \frac{h}{2} \right)^{2p-2} \left[ f^{(2p-3)}(b) - f^{(2p-3)(a)} \right] + O(h^{2p})
+&+ \cdots + K \left( \frac{h}{2} \right)^{2p-2} \left[ f^{(2p-3)}(b) - f^{(2p-3)}(a) \right] + O(h^{2p})
 \end{split}
 \\]
 
@@ -64,7 +68,7 @@ So that
 \\[
 \begin{split}
 \frac{4 T\_{\frac{h}{2}}(f) - T\_{h}(f)}{3} &= \int\_{a}^{b} f(x) dx + \left( \frac{h^4}{2880} \right) \left[ f^{(3)}(b) - f^{(3)}(a) \right] - \left( \frac{h^6}{96768} \right) \left[ f^{(5)}(b) - f^{(5)}(a) \right] \\\\
-&+ ... + K h^{2p-2} \left[ f^{(2p-3)}(b) - f^{(2p-3)(a)} \right] + O(h^{2p})
+&+ \cdots + K h^{2p-2} \left[ f^{(2p-3)}(b) - f^{(2p-3)}(a) \right] + O(h^{2p})
 \end{split}
 \\]
 
@@ -91,3 +95,7 @@ This process is continued until there is only one element in the last column, th
 is the estimate of the integral.
 
 The numbers which are used the divide the difference of two adjacent elements in the \\(i^{th}\\) column is \\(4^i - 1\\).
+
+## Limitations
+
+Romberg's method requires the integrand to be infinitely differentiable on \\([a, b]\\) for the Euler-Maclaurin expansion to hold. It is not appropriate for functions with singularities, discontinuities, or even kinks (non-differentiable points) in the integration interval. For such functions, consider the adaptive Simpson method or splitting the interval.

--- a/src/adaptive_quadrature.rs
+++ b/src/adaptive_quadrature.rs
@@ -1,3 +1,9 @@
+//! Adaptive Simpson quadrature for numerical integration.
+//!
+//! Unlike fixed-step methods, adaptive quadrature automatically refines the
+//! step size in regions where the integrand varies rapidly, achieving a
+//! user-specified tolerance with fewer function evaluations.
+
 use std::{
     fmt,
     ops::{AddAssign, MulAssign},
@@ -9,28 +15,32 @@ use crate::utils::adaptive_simpson::{simpson_rule_update, AdaptiveSimpsonError, 
 
 type Result<T> = std::result::Result<T, AdaptiveSimpsonError>;
 
-/// Simpson-Simpson adaptive method
+/// Numerically integrates $f$ over $[a, b]$ using the adaptive Simpson method.
 ///
-/// Integrate, using the Simpson-Simpson adaptive method, the user supplied function $f$ from $a$ to $b$.
+/// Starting at the left endpoint $a$, the algorithm finds the minimum power of 2, $m$,
+/// such that the difference between the single-interval Simpson estimate and the
+/// composite (two sub-subintervals) Simpson estimate on $\left[a,\\, a+\frac{b-a}{2^m}\right]$
+/// is less than the pro-rated tolerance:
 ///
-/// * `func` - Integrand function of a single variable.
-/// * `lower_limit` is the lower limit of integration.
-/// * `upper_limit`  is the upper limit of integration where `upper_limit` > `lower_limit`.
-/// * `tolerance` is the tolerance.
-/// * `min_h` is the minimum subinterval length to be used.
+/// $$2 \cdot \texttt{tolerance} \cdot \frac{\text{length of subinterval}}{b - a}$$
 ///
-/// Starting at the left-end point, `a`, find the min power of 2, $m$,
-/// so that the difference between using Simpson's rule and the composite Simpson's
-/// rule on the interval $\[a, a+\frac{b-a}{2^m}\]$ is less than
-/// $$ 2 * \verb|tolerance| * \frac{\text{length of the subinterval}}{b-a}$$
+/// The process then repeats for the remaining interval $\left[a + \frac{b-a}{2^m},\\, b\right]$,
+/// advancing until the right endpoint $b$ is reached.  The integral is the sum of the
+/// accepted subinterval estimates.
 ///
-/// Then repeat the process for integrating over the interval $\[a + \frac{b-a}{2^m}, b\]$ until the right
-/// end point, b, is finally reached.
+/// # Parameters
 ///
-/// The integral is then the sum of the integrals of each subinterval.  If at any time,
-/// the length of the subinterval for which the estimates based on Simpson's rule and
-/// the composite Simpson's rule is less than `min_h`, the process is terminated with an
-/// `AdaptiveSimpsonError` error.
+///  * `func` — Integrand $f$; a single-variable function.
+///  * `lower_limit` — Lower limit of integration $a$.
+///  * `upper_limit` — Upper limit of integration $b$; must satisfy `upper_limit > lower_limit`.
+///  * `min_h` — Minimum allowed subinterval length; must be a positive finite float.
+///  * `tolerance` — Desired absolute error bound; must be a positive finite float.
+///
+/// # Errors
+///
+/// Returns `Err(AdaptiveSimpsonError)` if a subinterval of length `min_h` is reached before the
+/// tolerance is satisfied. This typically means the integrand has a singularity or varies too
+/// rapidly — try increasing `tolerance` or decreasing `min_h`.
 ///
 /// # Examples
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,54 @@
 // #![feature(test)]
 
-//! Integrate is a small, lightweight Rust library for performing numerical integration of real-valued functions.
-//! It is designed to integrate functions, providing a simple and efficient way to
-//! approximate definite integrals using various numerical methods.
+//! A lightweight Rust library for numerical integration of real-valued functions.
 //!
-//! Numerical integration is concerned with developing algorithms to
-//! approximate the integral of a function $f(x)$. The most commonly used algorithms
-//! are Newton-Cotes formulas, Romberg's method, Gaussian quadrature, and to
-//! lesser extents Hermite's formulas and certain adaptive techniques.
+//! `integrate` approximates definite integrals of the form
+//!
+//! $$\int_a^b f(x)\\, dx$$
+//!
+//! using Newton-Cotes formulas, Gaussian quadrature, Romberg's method, and
+//! adaptive techniques.
+//!
+//! # Methods
+//!
+//! ## Newton-Cotes ([`newton_cotes`])
+//!
+//! | Function | Description |
+//! |---|---|
+//! | [`newton_cotes::rectangle_rule`] | Midpoint rectangle rule |
+//! | [`newton_cotes::trapezoidal_rule`] | Trapezoidal rule |
+//! | [`newton_cotes::simpson_rule`] | Simpson's 1/3 rule |
+//! | [`newton_cotes::newton_rule`] | Newton's 3/8 rule |
+//!
+//! ## Gaussian Quadrature ([`gauss_quadrature`])
+//!
+//! | Function | Description |
+//! |---|---|
+//! | [`gauss_quadrature::legendre_rule`] | Gauss-Legendre rule |
+//! | [`gauss_quadrature::gauss_laguerre_rule`] | Gauss-Laguerre rule |
+//! | [`gauss_quadrature::gauss_hermite_rule`] | Gauss-Hermite rule |
+//! | [`gauss_quadrature::gauss_first_kind_chebyshev_rule`] | Gauss-Chebyshev rule (first kind) |
+//! | [`gauss_quadrature::gauss_second_kind_chebyshev_rule`] | Gauss-Chebyshev rule (second kind) |
+//!
+//! ## Adaptive Quadrature ([`adaptive_quadrature`])
+//!
+//! | Function | Description |
+//! |---|---|
+//! | [`adaptive_quadrature::adaptive_simpson_method`] | Adaptive Simpson's method |
+//!
+//! ## Romberg ([`romberg`])
+//!
+//! | Function | Description |
+//! |---|---|
+//! | [`romberg::romberg_method`] | Romberg integration |
+//!
+//! # Quick Start
+//!
+//! ```rust
+//! use integrate::prelude::*;
+//! let result = trapezoidal_rule(|x: f64| x.exp(), 0.0, 1.0, 1000_usize);
+//! assert!((result - (std::f64::consts::E - 1.0)).abs() < 1e-6);
+//! ```
 //!
 //! # Caveats
 //!
@@ -15,32 +56,30 @@
 //! the integrand is continuous on the interval of integration. The error
 //! estimates generally require that the integrands are differentiable of
 //! whatever order is required so that the formula for the error estimate
-//! makes sense. Below is a check list which one should verify before using
-//! any of the numerical algorithms.
+//! makes sense. Below is a checklist to verify before using any of these
+//! algorithms.
 //!
-//! ### Integrand check list
+//! ### Integrand checklist
 //!
 //! - Are there any singularities of the integrand in the interval of integration?
 //!
 //!     - If there are, then can they be removed?
 //!
 //!     - A function which has jump discontinuities can be integrated by splitting
-//!       the interval of integration into subintervals on which the function is continuous,
-//!       and then numerically integrate over each subinterval and add the results.
-//!     
-//!     - Using integration by parts certain types of singular integrals can be
-//!       expressed as the sum of a function and a non-singular integral.
-//!     
-//!     - In other cases, an approximation of the integral in a small neighborhood of
-//!       the singularity can be obtained by hand and the interval of integration can be
-//!       split into three intervals in which numerical integration can be used on
-//!       two of them.
+//!       the interval of integration into subintervals on which the function is
+//!       continuous, then numerically integrating over each subinterval and summing
+//!       the results.
 //!
-//! - Does the function oscillate over the region of integration? If it does,
-//!   then make sure that the step size is chosen to be smaller than the wave length
-//!   of the function. The interval of integration can also be split into subintervals
-//!   in which each subinterval is half a wave length and the algorithm is applied
-//!   to each subinterval.
+//!     - Using integration by parts, certain types of singular integrals can be
+//!       expressed as the sum of a closed-form term and a non-singular integral.
+//!
+//!     - In other cases, an approximation of the integral in a small neighborhood of
+//!       the singularity can be obtained analytically, and the interval of integration
+//!       can be split so that numerical integration is used on the non-singular parts.
+//!
+//! - Does the function oscillate over the region of integration? If so, make sure
+//!   that the step size is smaller than the wavelength of the function. The interval
+//!   can also be split into subintervals of half a wavelength each.
 
 pub mod adaptive_quadrature;
 pub mod gauss_quadrature;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,6 +1,26 @@
-//! The integrate prelude imports the various Numerical Integration methods.
-//! The intention is that one can include `use integrate::prelude::*` and
-//! have easy access to the various methods you will need.
+//! Convenience re-exports of all public integration functions.
+//!
+//! Import everything at once with:
+//!
+//! ```rust
+//! use integrate::prelude::*;
+//! ```
+//!
+//! # Re-exported symbols
+//!
+//! | Symbol | Description |
+//! |---|---|
+//! | [`adaptive_simpson_method`] | Adaptive Simpson's method with automatic step-size refinement |
+//! | [`gauss_first_kind_chebyshev_rule`] | Gauss-Chebyshev quadrature rule of the first kind |
+//! | [`gauss_hermite_rule`] | Gauss-Hermite quadrature rule for integrals over $(-\infty, +\infty)$ |
+//! | [`gauss_laguerre_rule`] | Gauss-Laguerre quadrature rule for integrals over $[0, +\infty)$ |
+//! | [`gauss_second_kind_chebyshev_rule`] | Gauss-Chebyshev quadrature rule of the second kind |
+//! | [`legendre_rule`] | Gauss-Legendre quadrature rule |
+//! | [`newton_rule`] | Newton's 3/8 rule |
+//! | [`rectangle_rule`] | Midpoint rectangle rule |
+//! | [`simpson_rule`] | Simpson's 1/3 rule |
+//! | [`trapezoidal_rule`] | Trapezoidal rule |
+//! | [`romberg_method`] | Romberg integration using Richardson extrapolation |
 
 pub use crate::adaptive_quadrature::adaptive_simpson_method;
 pub use crate::gauss_quadrature::{

--- a/src/utils/adaptive_simpson.rs
+++ b/src/utils/adaptive_simpson.rs
@@ -2,14 +2,24 @@ use std::{fmt, ops::MulAssign};
 
 use num::Float;
 
+/// Represents a subinterval $[a, b]$ during adaptive subdivision, storing the function
+/// values at five evenly-spaced points and a linked pointer to the next pending subinterval.
 #[derive(Clone, Debug)]
 pub struct SubInterval<F: Float> {
+    /// Upper limit of the subinterval $b$.
     pub upper_limit: F,
+    /// Lower limit of the subinterval $a$.
     pub lower_limit: F,
+    /// Function evaluations at the five evenly-spaced points:
+    /// $a$, $a+h/4$, $(a+b)/2$, $b-h/4$, $b$,
+    /// where $h = b - a$.
     pub function: [F; 5],
+    /// Next pending subinterval in the stack; `None` if this is the last one.
     pub interval: Option<Box<SubInterval<F>>>,
 }
 
+/// Error returned when adaptive Simpson fails to meet tolerance before the minimum step size
+/// `min_h` is reached.
 #[derive(Debug, Clone)]
 pub struct AdaptiveSimpsonError;
 
@@ -20,6 +30,10 @@ impl fmt::Display for AdaptiveSimpsonError {
     }
 }
 
+/// Given a subinterval, evaluates the two missing function points and returns `(s1, s2)`
+/// where `s1` is the single-interval Simpson estimate and `s2` is the composite
+/// (two sub-subintervals) Simpson estimate.  The ratio $|s_1 - s_2|$ is used as a
+/// local error indicator.
 pub fn simpson_rule_update<Func, F: Float + MulAssign + fmt::Debug>(
     func: Func,
     pinterval: &mut SubInterval<F>,

--- a/src/utils/bessel.rs
+++ b/src/utils/bessel.rs
@@ -3,11 +3,14 @@ use std::f64::consts::PI;
 
 use num::{ToPrimitive, Unsigned};
 
-/// Computes the $k^{th}$ zero of the $J_0(x)$ Bessel function.
+/// Returns the $k$-th positive zero of the Bessel function $J_0(x)$.
 ///
-/// # Notes
+/// For $k \le 20$ the zero is read from a precomputed table of high-precision
+/// values.  For $k > 20$ the zero is approximated via McMahon's asymptotic
+/// expansion (see [`mcmahon_expansion`]).
 ///
-/// Note that the first 20 zeros are tabulated.  After that, they are computed using McMahon expansion
+/// This function is used internally to seed the node computation for
+/// Gauss-Legendre quadrature rules of large order.
 pub fn bessel_j0_zeros<U: Unsigned + ToPrimitive>(k: U) -> f64 {
     const J_Z: [f64; 20] = [
         2.404_825_557_695_773,
@@ -48,10 +51,13 @@ pub fn bessel_j0_zeros<U: Unsigned + ToPrimitive>(k: U) -> f64 {
     z
 }
 
-/// This functions is used to approximate the $k^{th}$ zero of the $J_0(x)$ Bessel function,
-/// for the case where $k$ is greater than 20.
+/// Applies McMahon's asymptotic expansion to refine the $k$-th zero of $J_0(x)$.
 ///
-/// Intended for internal use of this crate only, in this specific implementation of Gauss-Legendre's rule.
+/// The starting approximation is $z = \pi(k - \tfrac{1}{4})$; the expansion
+/// adds correction terms as a power series in $r = 1/z$ and $r^2$, improving
+/// accuracy for large $k$ (i.e. large zeros).
+///
+/// Intended for internal use within the Gauss-Legendre node computation.
 fn mcmahon_expansion(z: f64, r: f64, r2: f64) -> f64 {
     z + r
         * (0.125E+00
@@ -65,10 +71,14 @@ fn mcmahon_expansion(z: f64, r: f64, r2: f64) -> f64 {
                                         + r2 * 5.092_254_624_022_268E7))))))))
 }
 
-/// This function is used to approximate $J_1$ Bessel function,
-/// applied the $k$ zero of the $J_0(x)$ Bessel function, in the case where $k$ is greater than 21.
+/// Applies Hankel's asymptotic expansion to approximate $J_1(x_k)^2$, where
+/// $x_k$ is the $k$-th zero of $J_0$.
 ///
-/// Intended for internal use of this crate only, in this specific implementation of Gauss-Legendre's rule.
+/// The argument `x` is $1/(k - 1/4)$ (a small parameter for large $k$) and
+/// `x2 = x * x`.  The result is the squared value of $J_1$ evaluated at that
+/// zero, used as a weight denominator in Gauss-Legendre quadrature.
+///
+/// Intended for internal use within the Gauss-Legendre node computation.
 fn hankel_expansion(x: f64, x2: f64) -> f64 {
     x * (2.026_423_672_846_755_5E-1
         + x2 * x2

--- a/src/utils/checkers.rs
+++ b/src/utils/checkers.rs
@@ -1,10 +1,16 @@
 use num::{Float, Unsigned, Zero};
 
-/// Checks integral arguments for Newton-Codes methods
+/// Validates arguments common to all Newton-Cotes integration methods.
 ///
 /// * `a` - lower limit of the integration interval.
-/// * `b` - lower limit of the integration interval.
-/// * `n` - number of steps.
+/// * `b` - upper limit of the integration interval.
+/// * `n` - number of steps (sub-intervals).
+///
+/// # Panics
+///
+/// - Panics if `n` is zero.
+/// - Panics if `a` or `b` is infinite.
+/// - Panics if `a > b` (the lower limit must not exceed the upper limit).
 pub fn check_newton_method_args<F: Float, U: Unsigned>(a: F, b: F, n: U) {
     if n.is_zero() {
         panic!("number of steps can't be zero");
@@ -19,9 +25,13 @@ pub fn check_newton_method_args<F: Float, U: Unsigned>(a: F, b: F, n: U) {
     }
 }
 
-/// Checks integral arguments for Gauss-Laguerre rule
+/// Validates the degree argument for Gaussian quadrature rules.
 ///
-/// * `n` - number of steps.
+/// * `n` - number of quadrature nodes (must be at least 1).
+///
+/// # Panics
+///
+/// - Panics if `n` is zero.
 pub fn check_gauss_rule_args(n: usize) {
     if n.is_zero() {
         panic!("number of steps can't be zero");

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,8 @@
+//! Internal utilities for polynomial root-finding, quadrature node/weight
+//! computation, and input validation.
+//!
+//! This module is **not** part of the public API.
+
 pub mod adaptive_simpson;
 pub mod bessel;
 pub mod chebyshev;

--- a/src/utils/orthogonal_polynomials.rs
+++ b/src/utils/orthogonal_polynomials.rs
@@ -2,10 +2,24 @@ use std::{fmt::Debug, ops::AddAssign};
 
 use num::Float;
 
+/// A family of polynomials that are mutually orthogonal with respect to a
+/// weight function on a given interval.
+///
+/// Implementations of this trait are used internally to compute the nodes
+/// (zeros of the polynomial) and weights required by Gaussian quadrature rules.
+/// The nodes are derived from the eigenvalues of the associated Jacobi
+/// tridiagonal matrix via the Golub-Welsch algorithm.
 pub trait OrthogonalPolynomial<F: Float + Debug + AddAssign> {
+    /// Creates a polynomial of the given `degree`.
     fn new(degree: usize) -> Self;
 
+    /// Evaluates the polynomial at `x` using the three-term recurrence relation.
     fn eval(&self, x: F) -> F;
 
+    /// Returns the zeros of the polynomial.
+    ///
+    /// The zeros serve as the quadrature nodes for the corresponding Gaussian
+    /// rule. They are computed as the eigenvalues of the Jacobi tridiagonal
+    /// matrix associated with this polynomial family.
     fn zeros(&self) -> Vec<F>;
 }


### PR DESCRIPTION
## Summary

Comprehensive documentation overhaul: full rustdoc for all 11 public functions and thorough LaTeX/content fixes across all mdBook chapters. Stacked on #8.

## Rust doc comments

- Full rustdoc with description, arguments, examples, and LaTeX formulas for all 11 public integration functions
- Fix LaTeX rendering in KaTeX: collapse multi-line `$$...$$` to single lines, double-escape special chars (`\\,` `\\!`)
- Fix `trapezoidal_rule`: `f''(c)` → `f^{\\prime\\prime}(c)`, wrong variable `R_h` → `T_h`
- Fix `newton_rule`: `f^{3}` → `f^{(3)}`, heading typo "Newton'3/8" → "Newton's 3/8"
- Remove all `Sync`/`Send` mentions from doc comments (Rayon removed)

## mdBook

- Add `getting_started.md` chapter
- Add `python_api.md` chapter  
- Fix LaTeX: wrap bare `\\begin{align}` blocks in `\\\\[...\\\\]`, use `\\cdots` instead of unicode/literal ellipsis
- **Critical fix** `gauss_hermite.md`: wrong sign `e^{x^2}` → `e^{-x^2}`
- **Critical fix** `gauss_chebyshev.md`: inner product limits `(-∞,+∞)` → `(-1,1)`
- Fix `romberg.md`: broken superscript `f^{(2p-3)(a)}` → `f^{(2p-3)}(a)` (×3)
- Enable MathJax in `book.toml`