### PR TITLE
fix: fix inconsistency and add tests

### DIFF
--- a/src/newton_cotes.rs
+++ b/src/newton_cotes.rs
@@ -374,15 +374,19 @@ mod rectangle_rule_tests {
     // }
     #[test]
     #[should_panic(expected = "Integral limits a and b can't be NaN")]
-    fn test_lower_limit_nan(){
-        fn f(x: f64) -> f64 { x }
+    fn test_lower_limit_nan() {
+        fn f(x: f64) -> f64 {
+            x
+        }
         let _ = rectangle_rule(f, f64::NAN, 1.0, 1usize);
     }
 
     #[test]
     #[should_panic(expected = "Integral limits a and b can't be NaN")]
-    fn test_upper_limit_nan(){
-        fn f(x: f64) -> f64 { x }
+    fn test_upper_limit_nan() {
+        fn f(x: f64) -> f64 {
+            x
+        }
         let _ = rectangle_rule(f, 0.0, f64::NAN, 1usize);
     }
 }
@@ -477,15 +481,19 @@ mod trapezoidal_rule_tests {
     // }
     #[test]
     #[should_panic(expected = "Integral limits a and b can't be NaN")]
-    fn test_lower_limit_nan(){
-        fn f(x: f64) -> f64 { x }
+    fn test_lower_limit_nan() {
+        fn f(x: f64) -> f64 {
+            x
+        }
         let _ = trapezoidal_rule(f, f64::NAN, 1.0, 1usize);
     }
 
     #[test]
     #[should_panic(expected = "Integral limits a and b can't be NaN")]
-    fn test_upper_limit_nan(){
-        fn f(x: f64) -> f64 { x }
+    fn test_upper_limit_nan() {
+        fn f(x: f64) -> f64 {
+            x
+        }
         let _ = trapezoidal_rule(f, 0.0, f64::NAN, 1usize);
     }
 }
@@ -582,15 +590,19 @@ mod simpson_rule_tests {
 
     #[test]
     #[should_panic(expected = "Integral limits a and b can't be NaN")]
-    fn test_lower_limit_nan(){
-        fn f(x: f64) -> f64 { x }
+    fn test_lower_limit_nan() {
+        fn f(x: f64) -> f64 {
+            x
+        }
         let _ = simpson_rule(f, f64::NAN, 1.0, 1usize);
     }
 
     #[test]
     #[should_panic(expected = "Integral limits a and b can't be NaN")]
-    fn test_upper_limit_nan(){
-        fn f(x: f64) -> f64 { x }
+    fn test_upper_limit_nan() {
+        fn f(x: f64) -> f64 {
+            x
+        }
         let _ = simpson_rule(f, 0.0, f64::NAN, 1usize);
     }
 }
@@ -687,15 +699,19 @@ mod newton_rule_tests {
 
     #[test]
     #[should_panic(expected = "Integral limits a and b can't be NaN")]
-    fn test_lower_limit_nan(){
-        fn f(x: f64) -> f64 { x }
+    fn test_lower_limit_nan() {
+        fn f(x: f64) -> f64 {
+            x
+        }
         let _ = newton_rule(f, f64::NAN, 1.0, 1usize);
     }
 
     #[test]
     #[should_panic(expected = "Integral limits a and b can't be NaN")]
-    fn test_upper_limit_nan(){
-        fn f(x: f64) -> f64 { x }
+    fn test_upper_limit_nan() {
+        fn f(x: f64) -> f64 {
+            x
+        }
         let _ = newton_rule(f, 0.0, f64::NAN, 1usize);
     }
 }

--- a/src/newton_cotes.rs
+++ b/src/newton_cotes.rs
@@ -373,14 +373,14 @@ mod rectangle_rule_tests {
     //     })
     // }
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "Integral limits a and b can't be NaN")]
     fn test_lower_limit_nan(){
         fn f(x: f64) -> f64 { x }
         let _ = rectangle_rule(f, f64::NAN, 1.0, 1usize);
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "Integral limits a and b can't be NaN")]
     fn test_upper_limit_nan(){
         fn f(x: f64) -> f64 { x }
         let _ = rectangle_rule(f, 0.0, f64::NAN, 1usize);
@@ -476,14 +476,14 @@ mod trapezoidal_rule_tests {
     //     })
     // }
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "Integral limits a and b can't be NaN")]
     fn test_lower_limit_nan(){
         fn f(x: f64) -> f64 { x }
         let _ = trapezoidal_rule(f, f64::NAN, 1.0, 1usize);
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "Integral limits a and b can't be NaN")]
     fn test_upper_limit_nan(){
         fn f(x: f64) -> f64 { x }
         let _ = trapezoidal_rule(f, 0.0, f64::NAN, 1usize);
@@ -581,14 +581,14 @@ mod simpson_rule_tests {
     // }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "Integral limits a and b can't be NaN")]
     fn test_lower_limit_nan(){
         fn f(x: f64) -> f64 { x }
         let _ = simpson_rule(f, f64::NAN, 1.0, 1usize);
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "Integral limits a and b can't be NaN")]
     fn test_upper_limit_nan(){
         fn f(x: f64) -> f64 { x }
         let _ = simpson_rule(f, 0.0, f64::NAN, 1usize);
@@ -686,14 +686,14 @@ mod newton_rule_tests {
     // }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "Integral limits a and b can't be NaN")]
     fn test_lower_limit_nan(){
         fn f(x: f64) -> f64 { x }
         let _ = newton_rule(f, f64::NAN, 1.0, 1usize);
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "Integral limits a and b can't be NaN")]
     fn test_upper_limit_nan(){
         fn f(x: f64) -> f64 { x }
         let _ = newton_rule(f, 0.0, f64::NAN, 1usize);

--- a/src/newton_cotes.rs
+++ b/src/newton_cotes.rs
@@ -372,6 +372,19 @@ mod rectangle_rule_tests {
     //         rectangle_rule(f1, a, b, NUM_STEPS);
     //     })
     // }
+    #[test]
+    #[should_panic]
+    fn test_lower_limit_nan(){
+        fn f(x: f64) -> f64 { x }
+        let _ = rectangle_rule(f, f64::NAN, 1.0, 1usize);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_upper_limit_nan(){
+        fn f(x: f64) -> f64 { x }
+        let _ = rectangle_rule(f, 0.0, f64::NAN, 1usize);
+    }
 }
 
 #[cfg(test)]
@@ -462,6 +475,19 @@ mod trapezoidal_rule_tests {
     //         trapezoidal_rule(f1, a, b, NUM_STEPS);
     //     })
     // }
+    #[test]
+    #[should_panic]
+    fn test_lower_limit_nan(){
+        fn f(x: f64) -> f64 { x }
+        let _ = trapezoidal_rule(f, f64::NAN, 1.0, 1usize);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_upper_limit_nan(){
+        fn f(x: f64) -> f64 { x }
+        let _ = trapezoidal_rule(f, 0.0, f64::NAN, 1usize);
+    }
 }
 
 #[cfg(test)]
@@ -553,6 +579,20 @@ mod simpson_rule_tests {
     //         simpson_rule(f1, a, b, NUM_STEPS);
     //     })
     // }
+
+    #[test]
+    #[should_panic]
+    fn test_lower_limit_nan(){
+        fn f(x: f64) -> f64 { x }
+        let _ = simpson_rule(f, f64::NAN, 1.0, 1usize);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_upper_limit_nan(){
+        fn f(x: f64) -> f64 { x }
+        let _ = simpson_rule(f, 0.0, f64::NAN, 1usize);
+    }
 }
 
 #[cfg(test)]
@@ -644,4 +684,18 @@ mod newton_rule_tests {
     //         newton_rule(f1, a, b, NUM_STEPS);
     //     })
     // }
+
+    #[test]
+    #[should_panic]
+    fn test_lower_limit_nan(){
+        fn f(x: f64) -> f64 { x }
+        let _ = newton_rule(f, f64::NAN, 1.0, 1usize);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_upper_limit_nan(){
+        fn f(x: f64) -> f64 { x }
+        let _ = newton_rule(f, 0.0, f64::NAN, 1usize);
+    }
 }

--- a/src/romberg.rs
+++ b/src/romberg.rs
@@ -183,14 +183,14 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "Integral limits a and b can't be NaN")]
     fn test_lower_limit_nan() {
         fn f(x: f64) -> f64 { x }
         let _ = romberg_method(f, f64::NAN, 1.0, 1usize);
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "Integral limits a and b can't be NaN")]
     fn test_upper_limit_nan() {
         fn f(x: f64) -> f64 { x }
         let _ = romberg_method(f, 0.0, f64::NAN, 1usize);

--- a/src/romberg.rs
+++ b/src/romberg.rs
@@ -185,14 +185,18 @@ mod tests {
     #[test]
     #[should_panic(expected = "Integral limits a and b can't be NaN")]
     fn test_lower_limit_nan() {
-        fn f(x: f64) -> f64 { x }
+        fn f(x: f64) -> f64 {
+            x
+        }
         let _ = romberg_method(f, f64::NAN, 1.0, 1usize);
     }
 
     #[test]
     #[should_panic(expected = "Integral limits a and b can't be NaN")]
     fn test_upper_limit_nan() {
-        fn f(x: f64) -> f64 { x }
+        fn f(x: f64) -> f64 {
+            x
+        }
         let _ = romberg_method(f, 0.0, f64::NAN, 1usize);
     }
 }

--- a/src/romberg.rs
+++ b/src/romberg.rs
@@ -181,4 +181,18 @@ mod tests {
 
         assert!((integral - analytic_result).abs() < EPSILON);
     }
+
+    #[test]
+    #[should_panic]
+    fn test_lower_limit_nan() {
+        fn f(x: f64) -> f64 { x }
+        let _ = romberg_method(f, f64::NAN, 1.0, 1usize);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_upper_limit_nan() {
+        fn f(x: f64) -> f64 { x }
+        let _ = romberg_method(f, 0.0, f64::NAN, 1usize);
+    }
 }

--- a/src/utils/checkers.rs
+++ b/src/utils/checkers.rs
@@ -9,7 +9,7 @@ use num::{Float, Unsigned, Zero};
 /// # Panics
 ///
 /// - Panics if `n` is zero.
-/// - Panics if `a` or `b` is infinite.
+/// - Panics if `a` or `b` is infinite or NaN.
 /// - Panics if `a > b` (the lower limit must not exceed the upper limit).
 pub fn check_newton_method_args<F: Float, U: Unsigned>(a: F, b: F, n: U) {
     if n.is_zero() {
@@ -18,6 +18,10 @@ pub fn check_newton_method_args<F: Float, U: Unsigned>(a: F, b: F, n: U) {
 
     if a.is_infinite() | b.is_infinite() {
         panic!("Integral limits a and b can't be infinite");
+    }
+
+    if a.is_nan() || b.is_nan() {
+        panic!("Integral limits a and b can't be NaN");
     }
 
     if a > b {


### PR DESCRIPTION
For function `romberg_method`, the comment requires lower_limit and upper_limit not to be NaN.

```rust
///  # Panics
///  Delegates argument validation to `check_newton_method_args`,
///  which panics if `n_intervals` is zero, either limit is infinite or NaN, or `lower_limit > upper_limit`.
pub fn rectangle_rule<Func, F1: Float, F2: Float, U: Unsigned + ToPrimitive + Copy>(
    func: Func,
    lower_limit: F1,
    upper_limit: F1,
    n_intervals: U,
) -> f64
where
    Func: Fn(F1) -> F2,
{
    check_newton_method_args(lower_limit, upper_limit, n_intervals);
...
```

However, following tests fail as it will not panic when lower_limit or upper_limit is NaN.

```rust
#[test]
    #[should_panic]
    fn test_lower_limit_nan(){
        fn f(x: f64) -> f64 { x }
        let _ = rectangle_rule(f, f64::NAN, 1.0, 1uisze);
    }

    #[test]
    #[should_panic]
    fn test_upper_limit_nan(){
        fn f(x: f64) -> f64 { x }
        let _ = rectangle_rule(f, 0.0, f64::NAN, 1usize);
    }
```

The same 2 errors occurs in other 4 functions.
Check should be added in `check_newton_method_args` to fix these 10 problems, I also added corresponding tests.